### PR TITLE
Add timeline to the report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 next-version
 ============
 
+- report: add optional log timestamp to the anomaly context.
+- web: render unified timeline view.
+
 0.9.8
 =====
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,9 +452,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/crates/cli/src/dataset.rs
+++ b/crates/cli/src/dataset.rs
@@ -94,6 +94,7 @@ fn process(env: &Env, path: &Path, dataset: Dataset) -> Result<()> {
                     env,
                     &Source::from_pathbuf(fail.to_path_buf()),
                     &mut Some(logjuicer_model::unordered::KnownLines::new()),
+                    None,
                 )
                 .collect::<Result<Vec<AnomalyContext>>>()?;
             let anomalies_count = anomalies.len();

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -597,9 +597,13 @@ fn print_report(report: Report) {
             bytes_to_mb(log_report.byte_count)
         );
         log_report.anomalies.iter().for_each(|anomaly_context| {
+            let ts = match anomaly_context.anomaly.timestamp {
+                Some(logjuicer_report::Epoch(ts)) => format!("{ts} "),
+                None => "".to_string(),
+            };
             println!(
-                "  {}: {}",
-                anomaly_context.anomaly.pos, anomaly_context.anomaly.line
+                "  {}: {}{}",
+                anomaly_context.anomaly.pos, ts, anomaly_context.anomaly.line
             );
         })
     })

--- a/crates/iterator/src/iterator.rs
+++ b/crates/iterator/src/iterator.rs
@@ -30,6 +30,10 @@
 use bytes::{Buf, Bytes, BytesMut};
 use std::io::{Read, Result};
 
+// TODO: handle json line spread accross multiple line like:
+// {"date":1709049714.812167,"log":"2024-02-27 ....
+// ..., "podname":"zuul-scheduler-0","labels_run":"zuul-scheduler"}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 enum Sep {
     // A line return: '\n'

--- a/crates/model/benches/bench-model.rs
+++ b/crates/model/benches/bench-model.rs
@@ -27,6 +27,7 @@ pub fn model_process(c: &mut Criterion) {
                 false,
                 false,
                 &mut skip_lines,
+                None,
             );
             let _anomalies = processor.collect::<Result<Vec<_>, _>>().unwrap();
         })

--- a/crates/model/src/model.rs
+++ b/crates/model/src/model.rs
@@ -32,6 +32,7 @@ pub mod files;
 pub mod process;
 pub mod prow;
 mod reader;
+pub mod timestamps;
 pub mod unordered;
 pub mod urls;
 pub mod zuul;

--- a/crates/model/src/process.rs
+++ b/crates/model/src/process.rs
@@ -263,12 +263,16 @@ impl<'a, IR: IndexReader, R: Read> ChunkProcessor<'a, IR, R> {
 
                 last_context_pos = buffer_pos;
 
+                // TODO: parse timestamp from current line
+                let timestamp = None;
+
                 self.current_anomaly = Some(AnomalyContext {
                     before,
                     after: Vec::new(),
                     anomaly: Anomaly {
                         distance: *distance,
                         pos: *log_pos,
+                        timestamp,
                         line: log_line,
                     },
                 });
@@ -456,6 +460,7 @@ fn test_chunk_processor() {
             anomaly: Anomaly {
                 distance: 1.0,
                 pos: 3,
+                timestamp: None,
                 line: "Traceback oops".into(),
             },
         },
@@ -465,6 +470,7 @@ fn test_chunk_processor() {
             anomaly: Anomaly {
                 distance: 1.0,
                 pos: 5,
+                timestamp: None,
                 line: "another Traceback".into(),
             },
         },
@@ -534,6 +540,7 @@ fn test_extended_context() {
             anomaly: Anomaly {
                 distance: 1.0,
                 pos: 2,
+                timestamp: None,
                 line: "Traceback oops".into(),
             },
         },
@@ -548,6 +555,7 @@ fn test_extended_context() {
             anomaly: Anomaly {
                 distance: 1.0,
                 pos: 10,
+                timestamp: None,
                 line: "another Traceback".into(),
             },
         },

--- a/crates/model/src/timestamps.rs
+++ b/crates/model/src/timestamps.rs
@@ -13,6 +13,12 @@ pub enum TS {
 use logjuicer_report::Epoch;
 use TS::*;
 
+impl From<Epoch> for TS {
+    fn from(value: Epoch) -> Self {
+        Full(value)
+    }
+}
+
 pub fn parse_timestamp(line: &str) -> Option<TS> {
     if let Some(stripped) = line.strip_prefix("{\"date\":") {
         NaiveDateTime::parse_and_remainder(stripped, "%s.%3f")

--- a/crates/model/src/timestamps.rs
+++ b/crates/model/src/timestamps.rs
@@ -1,0 +1,131 @@
+// Copyright (C) 2024 Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+use chrono::Timelike;
+use chrono::{NaiveDateTime, NaiveTime};
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum TS {
+    Full(Epoch),
+    Time(u64),
+}
+
+use logjuicer_report::Epoch;
+use TS::*;
+
+pub fn parse_timestamp(line: &str) -> Option<TS> {
+    if let Some(stripped) = line.strip_prefix("{\"date\":") {
+        NaiveDateTime::parse_and_remainder(stripped, "%s.%3f")
+            .map(|(ndt, _)| Full(Epoch(ndt.timestamp_millis() as u64)))
+            .ok()
+    } else {
+        NaiveDateTime::parse_and_remainder(line, "%F %T,%3f")
+            .or_else(|_| NaiveDateTime::parse_and_remainder(line, "%FT%T"))
+            .or_else(|_| NaiveDateTime::parse_and_remainder(line, "%F %T.%3f"))
+            .or_else(|_| NaiveDateTime::parse_and_remainder(line, "[%Y/%m/%d %T]"))
+            .map(|(ndt, _)| Full(Epoch(ndt.timestamp_millis() as u64)))
+            .or_else(|_| {
+                NaiveTime::parse_and_remainder(line.get(6..).unwrap_or(""), "%T.%3f")
+                    .or_else(|_| NaiveTime::parse_and_remainder(line, "%b %d %T "))
+                    .map(|(nt, _)| {
+                        Time(
+                            (nt.num_seconds_from_midnight() as u64) * 1_000
+                                + ((nt.nanosecond() / 1_000_000) as u64),
+                        )
+                    })
+            })
+            .ok()
+    }
+}
+
+#[test]
+fn test_timestamp() {
+    assert_eq!(parse_timestamp("Feb 27 11:06:45 "), Some(Time(40005000)));
+    assert_eq!(
+        parse_timestamp("2024-02-27T15:58:33Z "),
+        Some(Full(Epoch(1709049513000)))
+    );
+    assert_eq!(
+        parse_timestamp("{\"date\":1708419555.859087,"),
+        Some(Full(Epoch(1708419555859)))
+    );
+    assert_eq!(
+        parse_timestamp("[2024/02/20 09:13:35]"),
+        Some(Full(Epoch(1708420415000)))
+    );
+    assert_eq!(
+        parse_timestamp("2024-02-20 09:15:54.012305"),
+        Some(Full(Epoch(1708420554012)))
+    );
+    assert_eq!(
+        parse_timestamp("2024-02-20 09:06:57,036 INFO"),
+        Some(Full(Epoch(1708420017036)))
+    );
+    assert_eq!(
+        parse_timestamp("I0220 08:45:08.004309  "),
+        Some(Time(31508004))
+    )
+}
+
+const HOUR: u64 = 3_600_000;
+const DAY: u64 = HOUR * 24;
+
+// Set date to time using a previously known datetime
+pub fn set_date(date_time: Epoch, time: u64) -> Epoch {
+    let known_time = date_time.0 % DAY;
+    let known_date = date_time.0 / DAY * DAY;
+    let diff = known_time.abs_diff(time);
+    Epoch(if known_time > time {
+        if diff > HOUR * 12 {
+            // 2024-01-01T23:00:00 and 01:01:01, the time is tomorrow
+            known_date + DAY + time
+        } else {
+            // 2024-01-01T23:00:00 and 22:01:01, the time is today, it happened before the known date
+            known_date + time
+        }
+    } else if diff > HOUR * 12 {
+        // 2024-01-01T01:01:01 and 23:00:00, the time is yesterday
+        known_date - DAY + time
+    } else {
+        // 2024-01-01T01:01:01 and 04:00:00
+        known_date + time
+    })
+}
+
+#[test]
+fn test_set_date() {
+    fn get_datetime(date_str: &str, time_str: &str) -> String {
+        let date = match parse_timestamp(date_str) {
+            Some(Full(d)) => d,
+            _ => panic!("bad date"),
+        };
+        let time = match parse_timestamp(time_str) {
+            Some(Time(t)) => t,
+            _ => panic!("bad time"),
+        };
+        let epoch = set_date(date, time);
+        chrono::DateTime::<chrono::Utc>::from_timestamp_millis(epoch.0 as i64)
+            .expect("invalid timestamp")
+            .to_string()
+    }
+    assert_eq!(
+        get_datetime("2024-02-27 11:05:43.333901", "Feb 27 10:41:36"),
+        "2024-02-27 10:41:36 UTC".to_string()
+    );
+    assert_eq!(
+        get_datetime("2000-01-01 23:00:00.000", "I0000 01:00:00.000"),
+        "2000-01-02 01:00:00 UTC".to_string()
+    );
+    assert_eq!(
+        get_datetime("2000-01-01 23:00:00.000", "I0000 18:00:00.000"),
+        "2000-01-01 18:00:00 UTC".to_string()
+    );
+    assert_eq!(
+        get_datetime("2000-01-01 01:00:00.000", "I0000 18:00:00.000"),
+        "1999-12-31 18:00:00 UTC".to_string()
+    );
+    assert_eq!(
+        get_datetime("2000-01-01 01:00:00.000", "I0000 05:00:00.000"),
+        "2000-01-01 05:00:00 UTC".to_string()
+    );
+}

--- a/crates/report/benches/bench-report.rs
+++ b/crates/report/benches/bench-report.rs
@@ -16,6 +16,7 @@ fn mk_report() -> Report {
             anomaly: Anomaly {
                 distance: 0.42,
                 pos,
+                timestamp: None,
                 line: line.as_str().into(),
             },
             after: vec!["after".into()],

--- a/crates/report/generated/schema_capnp.rs
+++ b/crates/report/generated/schema_capnp.rs
@@ -484,7 +484,7 @@ pub mod report {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
     }
     #[inline]
-    pub fn set_baselines(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::content::Owned>) -> ::capnp::Result<()> {
+    pub fn set_baselines(&mut self, value: ::capnp::struct_list::Reader<'_,crate::schema_capnp::content::Owned>) -> ::capnp::Result<()> {
       ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(1), value, false)
     }
     #[inline]
@@ -500,7 +500,7 @@ pub mod report {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::core::option::Option::None)
     }
     #[inline]
-    pub fn set_log_reports(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::log_report::Owned>) -> ::capnp::Result<()> {
+    pub fn set_log_reports(&mut self, value: ::capnp::struct_list::Reader<'_,crate::schema_capnp::log_report::Owned>) -> ::capnp::Result<()> {
       ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(2), value, false)
     }
     #[inline]
@@ -516,7 +516,7 @@ pub mod report {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), ::core::option::Option::None)
     }
     #[inline]
-    pub fn set_index_reports(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::property::Owned<crate::schema_capnp::index_report::Owned>>) -> ::capnp::Result<()> {
+    pub fn set_index_reports(&mut self, value: ::capnp::struct_list::Reader<'_,crate::schema_capnp::property::Owned<crate::schema_capnp::index_report::Owned>>) -> ::capnp::Result<()> {
       ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(3), value, false)
     }
     #[inline]
@@ -532,7 +532,7 @@ pub mod report {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(4), ::core::option::Option::None)
     }
     #[inline]
-    pub fn set_unknown_files(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::source::Owned>>>) -> ::capnp::Result<()> {
+    pub fn set_unknown_files(&mut self, value: ::capnp::struct_list::Reader<'_,crate::schema_capnp::property::Owned<::capnp::struct_list::Owned<crate::schema_capnp::source::Owned>>>) -> ::capnp::Result<()> {
       ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(4), value, false)
     }
     #[inline]
@@ -548,7 +548,7 @@ pub mod report {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(5), ::core::option::Option::None)
     }
     #[inline]
-    pub fn set_read_errors(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::read_error::Owned>) -> ::capnp::Result<()> {
+    pub fn set_read_errors(&mut self, value: ::capnp::struct_list::Reader<'_,crate::schema_capnp::read_error::Owned>) -> ::capnp::Result<()> {
       ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(5), value, false)
     }
     #[inline]
@@ -3225,7 +3225,7 @@ pub mod log_report {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
     }
     #[inline]
-    pub fn set_anomalies(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::anomaly_context::Owned>) -> ::capnp::Result<()> {
+    pub fn set_anomalies(&mut self, value: ::capnp::struct_list::Reader<'_,crate::schema_capnp::anomaly_context::Owned>) -> ::capnp::Result<()> {
       ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(0), value, false)
     }
     #[inline]
@@ -3569,7 +3569,7 @@ pub mod anomaly_context {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
     }
     #[inline]
-    pub fn set_before(&mut self, value: ::capnp::text_list::Reader<'a>) -> ::capnp::Result<()> {
+    pub fn set_before(&mut self, value: ::capnp::text_list::Reader<'_>) -> ::capnp::Result<()> {
       ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(0), value, false)
     }
     #[inline]
@@ -3601,7 +3601,7 @@ pub mod anomaly_context {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::core::option::Option::None)
     }
     #[inline]
-    pub fn set_after(&mut self, value: ::capnp::text_list::Reader<'a>) -> ::capnp::Result<()> {
+    pub fn set_after(&mut self, value: ::capnp::text_list::Reader<'_>) -> ::capnp::Result<()> {
       ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(2), value, false)
     }
     #[inline]
@@ -3798,11 +3798,15 @@ pub mod anomaly {
     pub fn has_line(&self) -> bool {
       !self.reader.get_pointer_field(0).is_null()
     }
+    #[inline]
+    pub fn get_timestamp(self) -> u64 {
+      self.reader.get_data_field::<u64>(1)
+    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
   impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 1 };
+    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 2, pointers: 1 };
   }
   impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
     const TYPE_ID: u64 = _private::TYPE_ID;
@@ -3884,6 +3888,14 @@ pub mod anomaly {
     pub fn has_line(&self) -> bool {
       !self.builder.is_pointer_field_null(0)
     }
+    #[inline]
+    pub fn get_timestamp(self) -> u64 {
+      self.builder.get_data_field::<u64>(1)
+    }
+    #[inline]
+    pub fn set_timestamp(&mut self, value: u64)  {
+      self.builder.set_data_field::<u64>(1, value);
+    }
   }
 
   pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -3895,45 +3907,52 @@ pub mod anomaly {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 63] = [
+    pub static ENCODED_NODE: [::capnp::Word; 79] = [
       ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
       ::capnp::word(138, 6, 206, 1, 232, 24, 86, 227),
-      ::capnp::word(13, 0, 0, 0, 1, 0, 1, 0),
+      ::capnp::word(13, 0, 0, 0, 1, 0, 2, 0),
       ::capnp::word(105, 176, 124, 221, 123, 244, 235, 248),
       ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(21, 0, 0, 0, 170, 0, 0, 0),
       ::capnp::word(29, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(25, 0, 0, 0, 175, 0, 0, 0),
+      ::capnp::word(25, 0, 0, 0, 231, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(115, 99, 104, 101, 109, 97, 46, 99),
       ::capnp::word(97, 112, 110, 112, 58, 65, 110, 111),
       ::capnp::word(109, 97, 108, 121, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
-      ::capnp::word(12, 0, 0, 0, 3, 0, 4, 0),
+      ::capnp::word(16, 0, 0, 0, 3, 0, 4, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(69, 0, 0, 0, 74, 0, 0, 0),
+      ::capnp::word(97, 0, 0, 0, 74, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(68, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(80, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(96, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(108, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(77, 0, 0, 0, 34, 0, 0, 0),
+      ::capnp::word(105, 0, 0, 0, 34, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(72, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(84, 0, 0, 0, 2, 0, 1, 0),
-      ::capnp::word(2, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(100, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(112, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(3, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(81, 0, 0, 0, 42, 0, 0, 0),
+      ::capnp::word(109, 0, 0, 0, 42, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(76, 0, 0, 0, 3, 0, 1, 0),
-      ::capnp::word(88, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(104, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(116, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(2, 0, 0, 0, 1, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 3, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(113, 0, 0, 0, 82, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(112, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(124, 0, 0, 0, 2, 0, 1, 0),
       ::capnp::word(100, 105, 115, 116, 97, 110, 99, 101),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(10, 0, 0, 0, 0, 0, 0, 0),
@@ -3959,12 +3978,22 @@ pub mod anomaly {
       ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(116, 105, 109, 101, 115, 116, 97, 109),
+      ::capnp::word(112, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
     ];
     pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
       match index {
         0 => <f32 as ::capnp::introspect::Introspect>::introspect(),
         1 => <u32 as ::capnp::introspect::Introspect>::introspect(),
         2 => <::capnp::text::Owned as ::capnp::introspect::Introspect>::introspect(),
+        3 => <u64 as ::capnp::introspect::Introspect>::introspect(),
         _ => panic!("invalid field index {}", index),
       }
     }
@@ -3976,7 +4005,7 @@ pub mod anomaly {
       nonunion_members: NONUNION_MEMBERS,
       members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
     };
-    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2];
+    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2,3];
     pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
     pub const TYPE_ID: u64 = 0xe356_18e8_01ce_068a;
   }
@@ -4122,7 +4151,7 @@ pub mod index_report {
       ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
     }
     #[inline]
-    pub fn set_sources(&mut self, value: ::capnp::struct_list::Reader<'a,crate::schema_capnp::source::Owned>) -> ::capnp::Result<()> {
+    pub fn set_sources(&mut self, value: ::capnp::struct_list::Reader<'_,crate::schema_capnp::source::Owned>) -> ::capnp::Result<()> {
       ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.reborrow().get_pointer_field(0), value, false)
     }
     #[inline]

--- a/crates/report/schema.capnp
+++ b/crates/report/schema.capnp
@@ -87,6 +87,7 @@ struct AnomalyContext {
 struct Anomaly {
   distance   @0 :Float32;
   pos        @1 :UInt32;
+  timestamp  @3 :UInt64;
   line       @2 :Text;
 }
 

--- a/crates/report/src/codec.rs
+++ b/crates/report/src/codec.rs
@@ -141,6 +141,7 @@ impl ReportEncoder {
         builder.set_distance(anomaly.distance);
         builder.set_pos(anomaly.pos as u32);
         builder.set_line(anomaly.line.as_ref().into());
+        builder.set_timestamp(anomaly.timestamp.unwrap_or(0));
         Ok(())
     }
 
@@ -368,10 +369,15 @@ impl ReportDecoder {
     }
 
     fn read_anomaly(&self, reader: &schema_capnp::anomaly::Reader) -> Result<Anomaly> {
+        let timestamp = match reader.get_timestamp() {
+            0 => None,
+            n => Some(n),
+        };
         Ok(Anomaly {
             // distance: (1.0 / 255.0) * reader.get_distance() as f32,
             distance: reader.get_distance(),
             pos: reader.get_pos() as usize,
+            timestamp,
             line: reader.get_line()?.to_str()?.into(),
         })
     }

--- a/crates/report/src/codec.rs
+++ b/crates/report/src/codec.rs
@@ -141,7 +141,7 @@ impl ReportEncoder {
         builder.set_distance(anomaly.distance);
         builder.set_pos(anomaly.pos as u32);
         builder.set_line(anomaly.line.as_ref().into());
-        builder.set_timestamp(anomaly.timestamp.unwrap_or(0));
+        builder.set_timestamp(anomaly.timestamp.unwrap_or(Epoch(0)).0);
         Ok(())
     }
 
@@ -371,7 +371,7 @@ impl ReportDecoder {
     fn read_anomaly(&self, reader: &schema_capnp::anomaly::Reader) -> Result<Anomaly> {
         let timestamp = match reader.get_timestamp() {
             0 => None,
-            n => Some(n),
+            n => Some(Epoch(n)),
         };
         Ok(Anomaly {
             // distance: (1.0 / 255.0) * reader.get_distance() as f32,

--- a/crates/report/src/report.rs
+++ b/crates/report/src/report.rs
@@ -300,7 +300,7 @@ impl std::fmt::Display for Source {
 }
 
 /// A timestamp in ms since epoch
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Epoch(pub u64);
 

--- a/crates/report/src/report.rs
+++ b/crates/report/src/report.rs
@@ -69,6 +69,7 @@ impl Report {
                     anomaly: Anomaly {
                         distance: 0.5,
                         pos: 1,
+                        timestamp: None,
                         line: "anomaly".into(),
                     },
                     after: vec![],
@@ -302,6 +303,7 @@ impl std::fmt::Display for Source {
 pub struct Anomaly {
     pub distance: f32,
     pub pos: usize,
+    pub timestamp: Option<u64>,
     pub line: Rc<str>,
 }
 
@@ -361,6 +363,7 @@ fn test_report_sort() {
             anomaly: Anomaly {
                 distance: if name == "failure.log" { 0.5 } else { 0.2 },
                 pos: 0,
+                timestamp: None,
                 line: "line".into(),
             },
             before: Vec::new(),

--- a/crates/report/src/report.rs
+++ b/crates/report/src/report.rs
@@ -255,7 +255,7 @@ impl std::fmt::Display for Content {
 }
 
 /// The location of the log lines, and the relative prefix length.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Eq, Hash, PartialOrd, Ord)]
 pub enum Source {
     Local(usize, PathBuf),
     Remote(usize, Url),

--- a/crates/report/src/report.rs
+++ b/crates/report/src/report.rs
@@ -299,11 +299,16 @@ impl std::fmt::Display for Source {
     }
 }
 
+/// A timestamp in ms since epoch
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Epoch(pub u64);
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Anomaly {
     pub distance: f32,
     pub pos: usize,
-    pub timestamp: Option<u64>,
+    pub timestamp: Option<Epoch>,
     pub line: Rc<str>,
 }
 
@@ -349,6 +354,12 @@ impl LogReport {
             .sorted_by(|a, b| b.1.total_cmp(&a.1))
             .map(|(lr, _mean)| lr)
             .collect()
+    }
+
+    pub fn timed(&self) -> impl Iterator<Item = (Epoch, &AnomalyContext)> {
+        self.anomalies
+            .iter()
+            .filter_map(|ac| ac.anomaly.timestamp.map(|ts| (ts, ac)))
     }
 }
 

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -39,3 +39,9 @@
   position: sticky;
   top: 24px;
 }
+
+.content .header2 {
+  width: 100%;
+  position: sticky;
+  top: 44px;
+}


### PR DESCRIPTION
This PR adds support for log line timestamps to create a chronological view of the anomalies found across multiple files. This can be useful for distributed systems where the earliest anomalies are likely to be most important compared to the last ones which are often emitted by the failure logs collections.

- [x] timestamp parser
- [x] timeline render in the web view
- [x] documentation/changelog