### PR TITLE
cargo: activate build optimizations for dependencies in dev mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,11 @@ lto = true
 opt-level = 's'
 # Perform optimizations on all codegen units.
 codegen-units = 1
+
+# Enable a small amount of optimization in debug mode
+[profile.dev]
+opt-level = 1
+
+# Enable high optimizations for dependencies (incl. Bevy), but not for our code:
+[profile.dev.package."*"]
+opt-level = 3


### PR DESCRIPTION
This change improves the performance of running logjuicer without the --release flag