### PR TITLE
decouple --report and --open option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ next-version
 - web: use a mono space font for log lines.
 - web: add a form to create similarity reports.
 - api: extra_baselines are now stored in a dedicated model to be rebuilt when the files are updated.
+- cli: --open and --report can now be used independently.
 
 0.10.0
 ======


### PR DESCRIPTION
This change simplifies a bit the process funtion by decoupling in three distinc run mode:

- liveview: build and display report in the terminal)
- open: build and open display in browser
- report: build and save the report on the filesystem

related to issue #127