### PR TITLE
api: fix LOGJUICER_CA_EXTRA usage when a bundle already exists.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+          toolchain: 1.75.0
 
       - name: Cache
         uses: Swatinem/rust-cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 next-version
 ============
 
+- api: fix LOGJUICER_CA_EXTRA usage when a bundle already exists.
+
 0.12.0
 ======
 


### PR DESCRIPTION
This change ensure the LOGJUICER_CA_EXTRA is loaded along a local or provided bundle..