### PR TITLE
web: show the relative source path for the report progress

### DIFF
--- a/crates/web-service/src/routes.rs
+++ b/crates/web-service/src/routes.rs
@@ -287,7 +287,7 @@ pub async fn do_report_watch(
                     let current = monitor.current.lock().unwrap();
                     match &*current {
                         Some(source) => {
-                            let source_str = source.as_str();
+                            let source_str = source.get_relative();
                             if prev_current.as_str()["Processing: ".len()..] != *source_str {
                                 let source_message: Utf8Bytes =
                                     format!("Processing: {}", source_str).into();


### PR DESCRIPTION
This change improves the user interface by showing the relative path instead of the full url of the current source.